### PR TITLE
PFM-4795 If the description of the project is long in all search screens, if the user searches based on application number tooltip info not showing properly

### DIFF
--- a/frontend/micro-ui/web/micro-ui-internals/packages/css/src/index.scss
+++ b/frontend/micro-ui/web/micro-ui-internals/packages/css/src/index.scss
@@ -986,7 +986,6 @@ input[type="number"] {
     td:nth-child(2){
       .tooltip {
           .tooltiptext {
-              top: 100% !important;
               bottom: 0% !important;
               height: max-content;
           }


### PR DESCRIPTION
PFM-4795 If the description of the project is long in all search screens, if the user searches based on application number tooltip info not showing properly